### PR TITLE
Upgrade lib to use 2024 version of wpilibNewCommands

### DIFF
--- a/Robot2024/lib/build.gradle
+++ b/Robot2024/lib/build.gradle
@@ -41,8 +41,6 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-	implementation 'edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:2023.4.3'
-
     testImplementation 'junit:junit:4.13'
 }
 

--- a/Robot2024/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/Robot2024/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -129,25 +129,17 @@ public abstract class MotorSubsystem<T extends Enum<T> & MotorSubsystem.Position
 	}
 
 	/**
-	 * Sets the desired setpoint to the current setpoint, and enables the pid
-	 * controll
-	 * 
-	 * @param setpoint the position to go to
-	 */
-	public void setSetpoint(double setpoint) {
-		if (!isEnabled()) {
-			enable();
-		}
-		super.setSetpoint(setpoint);
-	}
-
-	/**
-	 * Sets the desired setpoint to the current setpoint, and enables the pid
-	 * controll
+	 * Sets the desired setpoint to the current setpoint, and enables the PID.
+	 * control.
+	 *
+	 * <p>Prefer calling this over calling {@link #setSetpoint(double)}.
 	 * 
 	 * @param setpoint the position to go to
 	 */
 	public void setSetpoint(T setpoint) {
+		if (!isEnabled()) {
+			enable();
+		}
 		setSetpoint(setpoint.getPos());
 	}
 

--- a/Robot2024/lib/vendordeps/WPILibNewCommands.json
+++ b/Robot2024/lib/vendordeps/WPILibNewCommands.json
@@ -1,0 +1,38 @@
+{
+  "fileName": "WPILibNewCommands.json",
+  "name": "WPILib-New-Commands",
+  "version": "1.0.0",
+  "uuid": "111e20f7-815e-48f8-9dd6-e675ce75b266",
+  "frcYear": "2024",
+  "mavenUrls": [],
+  "jsonUrl": "",
+  "javaDependencies": [
+    {
+      "groupId": "edu.wpi.first.wpilibNewCommands",
+      "artifactId": "wpilibNewCommands-java",
+      "version": "wpilib"
+    }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": [
+    {
+      "groupId": "edu.wpi.first.wpilibNewCommands",
+      "artifactId": "wpilibNewCommands-cpp",
+      "version": "wpilib",
+      "libName": "wpilibNewCommands",
+      "headerClassifier": "headers",
+      "sourcesClassifier": "sources",
+      "sharedLibrary": true,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "linuxathena",
+        "linuxarm32",
+        "linuxarm64",
+        "windowsx86-64",
+        "windowsx86",
+        "linuxx86-64",
+        "osxuniversal"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The code in Robot2024 already uses this version.

- Copy WPILibNewCommands.json from vendordeps/ to lib/vendordeps
- Remove wpilibNewCommands from lib/build.gradle
- Remove override of MotorSubsystem.setSetpoint(double) (this method is now final in the
  base class)